### PR TITLE
chore: disable Renovate (dormant repo)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "enabled": false
 }


### PR DESCRIPTION
Sets `"enabled": false` in `renovate.json` to stop Renovate activity on this repository.

This repo has had no human commits in 6+ months (only Renovate/bot activity). It was surfaced by an org-wide audit of Renovate-configured repos with no recent human activity — see WillowInc/AzurePlatform#5292 for the full list and rationale.

**Why `enabled: false` rather than deleting `renovate.json`:** the org uses Renovate autodiscovery + onboarding, so deleting the config would just trigger a fresh "Configure Renovate" onboarding PR. Setting `enabled: false` is the documented, reversible off-switch — Renovate reads it and skips the repo entirely.

**Note:** this also stops security/vulnerability PRs for this repo. If the repo is later reactivated, flip `enabled` back to `true` (or delete this line) to resume. If the repo is truly dead, consider archiving it instead (archiving stops Renovate too) — tracked in WillowInc/AzurePlatform#5292.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>